### PR TITLE
Some important archiving fixes

### DIFF
--- a/facebook.js
+++ b/facebook.js
@@ -1,8 +1,8 @@
-var userStorage = new Session({ // Collect basic targeting data across user's devices
+var userStorage = new ChromeStorage({ // Collect basic targeting data across user's devices
 	targetingHistory: [],
 }, "sync")
 
-var browserStorage = new Session({ // Maintain a record of advert snapshots on this device
+var browserStorage = new ChromeStorage({ // Maintain a record of advert snapshots on this device
 	advertArchive: [],
 }, "local")
 

--- a/facebook.js
+++ b/facebook.js
@@ -97,9 +97,11 @@ $(document).ready(function() {
 					// console.log("Processed Ad No.",uiIndex,advertiserName,top_level_post_id);
 					adContent.attr('WTM_timestamp_snapshot', snapshot_meta.timestamp_snapshot);
 
-					newSessionHistory.meta.push(snapshot_meta)
-					newSessionHistory.content.push(snapshot_content)
-					newSessionHistory.blobs.push(snapshot_blobs)
+					newSessionHistory.push({
+						meta: snapshot_meta,
+						content: snapshot_content,
+						blobs: snapshot_blobs,
+					});
 
 					inspectNextAd();
 				}
@@ -120,28 +122,20 @@ $(document).ready(function() {
 
 		// See if there are adverts new to the `oldSessionHistory`, to be POST'd and SESSION'd
 		function synchronise(newSessionHistory) {
-			console.log("Sync'ing ads just found ("+newSessionHistory.meta.length+") w/ ads this session's history ("+oldSessionHistory.meta.length+").");
+			console.log("Sync'ing ads just found ("+newSessionHistory.length+") w/ ads this session's history ("+oldSessionHistory.length+").");
 			console.log(newSessionHistory, oldSessionHistory)
 
-			if(newSessionHistory.meta.length == oldSessionHistory.meta.length
-				&& newSessionHistory.meta.slice(-1)[0].top_level_post_id == oldSessionHistory.meta.slice(-1)[0].top_level_post_id
+			if(newSessionHistory.length == oldSessionHistory.length
+				&& newSessionHistory.slice(-1)[0].meta.top_level_post_id == oldSessionHistory.slice(-1)[0].meta.top_level_post_id
 			) {
-				console.log("--No new adverts--",newSessionHistory.meta.slice(-1)[0].top_level_post_id,oldSessionHistory.meta.slice(-1)[0].top_level_post_id);
+				console.log("--No new adverts--",newSessionHistory.slice(-1)[0].meta.top_level_post_id,oldSessionHistory.slice(-1)[0].meta.top_level_post_id);
 			} else {
-				var diffLength = newSessionHistory.meta.length - oldSessionHistory.meta.length;
-				newAdvertsMeta = newSessionHistory.meta.slice(-1 * diffLength);
+				var diffLength = newSessionHistory.length - oldSessionHistory.length;
+				newAdverts = newSessionHistory.slice(-1 * diffLength);
 
-				var newAdverts = newAdvertsMeta.map(function(adMeta, index) {
-					return Object.assign({},
-						{meta: adMeta},
-						{content: newSessionHistory.content[index]},
-						{blobs: newSessionHistory.blobs[index]}
-					)
-				});
-
-				newSessionHistory.meta.forEach((x) => console.log("new:",x.entity));
-				oldSessionHistory.meta.forEach((x) => console.log("old:",x.entity));
-				console.log("diff of "+diffLength,newAdverts);
+				newSessionHistory.forEach((x) => console.log("new:",x.meta.entity));
+				oldSessionHistory.forEach((x) => console.log("old:",x.meta.entity));
+				console.log("diff of "+diffLength, newAdverts);
 
 				newAdverts.forEach(function(ad, index) {
 					// Only save small text to user session

--- a/facebook.js
+++ b/facebook.js
@@ -7,18 +7,10 @@ var browserStorage = new ChromeStorage({ // Maintain a record of advert snapshot
 }, "local")
 
 $(document).ready(function() {
-	var oldSessionHistory = {
-		meta: [],
-		content: [],
-		blobs: [],
-	}
+	var oldSessionHistory = []
 
 	window.setInterval(function() {
-		var newSessionHistory = {
-			meta: [],
-			content: [],
-			blobs: [],
-		}
+		var newSessionHistory = []
 
 		thisBatchN = $("a:contains('Sponsored')").length;
 		$("a:contains('Sponsored')").each(function(index) {

--- a/facebook.js
+++ b/facebook.js
@@ -1,19 +1,28 @@
-var userStorage = new Session({
-	advertHistory: []
-})
+var userStorage = new Session({ // Collect basic targeting data across user's devices
+	targetingHistory: [],
+}, "sync")
 
-var currentSessionHistory = []; // HTML / image data too large to store in `chrome.storage`
-
-Array.prototype.diff = function(a) { // Polyfill diff function
-	return this.filter(function(i) {return a.indexOf(i) < 0;});
-};
+var browserStorage = new Session({ // Maintain a record of advert snapshots on this device
+	advertArchive: [],
+}, "local")
 
 $(document).ready(function() {
+	var oldSessionHistory = {
+		meta: [],
+		content: [],
+		blobs: [],
+	}
+
 	window.setInterval(function() {
-		var updatedSessionHistory = []
+		var newSessionHistory = {
+			meta: [],
+			content: [],
+			blobs: [],
+		}
 
 		thisBatchN = $("a:contains('Sponsored')").length;
 		$("a:contains('Sponsored')").each(function(index) {
+			var uiIndex = index+1;
 			var advertiserHTML = $(this).closest('div').prev().find('a:first-of-type');
 			var advertiserName = advertiserHTML.text();
 			var top_level_post_id = /\[top_level_post_id\]=([0-9]+)/.exec(advertiserHTML.attr('href'));
@@ -22,7 +31,10 @@ $(document).ready(function() {
 			// Check that it's an identifiable post
 			if(advertiserName && top_level_post_id != null && top_level_post_id.constructor === Array) {
 				top_level_post_id = top_level_post_id[1];
+				console.log("Inspecting suspected advert No."+uiIndex+" of "+thisBatchN,advertiserName,top_level_post_id);
+
 				var adContent = $(this).closest('div').prev().find('a:first-of-type').closest('.fbUserContent');
+				adContent.attr('WTM_timestamp_snapshot') ? console.log("!!! Already archived ",advertiserName,top_level_post_id) : console.log("+++ Probably new");
 
 				// Get image/video thumbnail URL
 				if(adContent.find('.fbStoryAttachmentImage')) {
@@ -42,13 +54,16 @@ $(document).ready(function() {
 				}
 
 				// Snapshots are sent to storage, and kept in user session history too.
-				var snapshot = {
+				var snapshot_meta = {
 					entity: advertiserName,
 					entityID: parseInt(advertiserID),
-					timestamp_created: parseInt(adContent.closest('[data-timestamp]').attr('data-timestamp')),
-					// Divide by 1000 to match the above, which is in seconds, compatibility for PHP
-					timestamp_snapshot: parseInt((Date.now() / 1000).toFixed()),
 					top_level_post_id: parseInt(top_level_post_id),
+					timestamp_created: parseInt(adContent.closest('[data-timestamp]').attr('data-timestamp')),
+					// Divide by 1000 to match FB's `timestamp` property (^), which is in seconds, compatibility for PHP
+					timestamp_snapshot: parseInt(adContent.attr('WTM_timestamp_snapshot')) || parseInt((Date.now() / 1000).toFixed()),
+				}
+
+				var snapshot_content = {
 					// May need to go through Facebook gateway, to get REAL url?
 					linkTo: linkTo,
 					postText: adContent.find('.userContent').text(),
@@ -79,42 +94,72 @@ $(document).ready(function() {
 				}
 
 				function saveSnapshot() {
-					// console.log("Noted an ad by "+snapshot.entity,snapshot.top_level_post_id)
-					updatedSessionHistory.push({'snapshot':snapshot,'snapshot_blobs':snapshot_blobs});
-					if(index == thisBatchN-1) {
-						synchronise(updatedSessionHistory);
-					}
+					// console.log("Processed Ad No.",uiIndex,advertiserName,top_level_post_id);
+					adContent.attr('WTM_timestamp_snapshot', snapshot_meta.timestamp_snapshot);
+
+					newSessionHistory.meta.push(snapshot_meta)
+					newSessionHistory.content.push(snapshot_content)
+					newSessionHistory.blobs.push(snapshot_blobs)
+
+					inspectNextAd();
+				}
+			} else {
+				console.log("Inspecting suspected non-advert No."+uiIndex+" of "+thisBatchN);
+				inspectNextAd();
+			}
+
+			function inspectNextAd() {
+				if(uiIndex < thisBatchN) {
+					// inspect next ad
+				} else {
+					// console.log("Inspection of "+thisBatchN+" adverts COMPLETE.");
+					synchronise(newSessionHistory);
 				}
 			}
 		})
 
-		function synchronise(updatedSessionHistory) {
-			console.log("Sync'ing ads just found ("+updatedSessionHistory.length+") w/ ads this session's history ("+currentSessionHistory.length+").");
-			// See if there are adverts new to the `currentSessionHistory`, to be POST'd and SESSION'd
-			if(updatedSessionHistory.length != currentSessionHistory.length) {
-				var newAdverts = updatedSessionHistory.diff(currentSessionHistory)
-				newAdverts.map(function(ad, index) {
+		// See if there are adverts new to the `oldSessionHistory`, to be POST'd and SESSION'd
+		function synchronise(newSessionHistory) {
+			console.log("Sync'ing ads just found ("+newSessionHistory.meta.length+") w/ ads this session's history ("+oldSessionHistory.meta.length+").");
+			console.log(newSessionHistory, oldSessionHistory)
+
+			if(newSessionHistory.meta.length == oldSessionHistory.meta.length
+				&& newSessionHistory.meta.slice(-1)[0].top_level_post_id == oldSessionHistory.meta.slice(-1)[0].top_level_post_id
+			) {
+				console.log("--No new adverts--",newSessionHistory.meta.slice(-1)[0].top_level_post_id,oldSessionHistory.meta.slice(-1)[0].top_level_post_id);
+			} else {
+				var diffLength = newSessionHistory.meta.length - oldSessionHistory.meta.length;
+				newAdvertsMeta = newSessionHistory.meta.slice(-1 * diffLength);
+
+				var newAdverts = newAdvertsMeta.map(function(adMeta, index) {
+					return Object.assign({},
+						{meta: adMeta},
+						{content: newSessionHistory.content[index]},
+						{blobs: newSessionHistory.blobs[index]}
+					)
+				});
+
+				newSessionHistory.meta.forEach((x) => console.log("new:",x.entity));
+				oldSessionHistory.meta.forEach((x) => console.log("old:",x.entity));
+				console.log("diff of "+diffLength,newAdverts);
+
+				newAdverts.forEach(function(ad, index) {
 					// Only save small text to user session
-					userStorage.add('advertHistory', ad.snapshot);
-					console.log("New ad [USER SYNC'D] Advertiser: "+ad.snapshot.entity+" - Advert ID: "+ad.snapshot.top_level_post_id, ad.snapshot);
+					userStorage.add('targetingHistory', ad.meta);
+					var browserSnapshot = Object.assign({}, ad.meta, ad.content);
+					browserStorage.add('advertArchive', browserSnapshot);
+					console.log("New ad [USER SYNC'D] Advertiser: "+browserSnapshot.entity+" - Advert ID: "+browserSnapshot.top_level_post_id, browserSnapshot);
 					// Save the whole shabang to server
-					var wholeShabang = Object.assign({}, ad.snapshot, ad.snapshot_blobs);
+					var wholeShabang = Object.assign({}, ad.meta, ad.content, ad.blobs);
 					$.post("https://who-targets-me.herokuapp.com/analytics/", wholeShabang, function( data ) {
 						console.log("This new ad [SERVER SYNC'D] Advertiser: "+wholeShabang.entity+" - Advert ID: "+wholeShabang.top_level_post_id, wholeShabang);
 					});
 				})
-				currentSessionHistory = updatedSessionHistory;
+				oldSessionHistory = newSessionHistory;
 			}
 		}
 	}, 5000);
 });
-
-var timestamp = Math.floor(Date.now());
-function updateAdvertDB(timestamp, data) {
-	chrome.storage.sync.set({timestamp: data}, function() {
-		console.log("Data saved");
-	});
-}
 
 function getParameterByName(name, url) {
     if (!url) url = window.location.href;

--- a/manifest.json
+++ b/manifest.json
@@ -11,17 +11,15 @@
 		"contextMenus",
 		"tabs",
 		"storage",
-		"*://*.facebook.com/*"
+		"*://*.facebook.com/*",
+	    "http://fonts.googleapis.com/",
+	    "https://fonts.googleapis.com/"
 	],
 	"content_scripts": [
 		{
 			"matches": ["*://*.facebook.com/*"],
       "js": ["jquery-3.2.1.min.js", "html2canvas.js", "session.js", "facebook.js"]
 		}
-	],
-	"permissions": [
-	    "http://fonts.googleapis.com/",
-	    "https://fonts.googleapis.com/"
 	],
 	"icons":
 	{

--- a/session.js
+++ b/session.js
@@ -20,13 +20,14 @@ thisSession.onChange({
 });
 */
 
-// Use when you need to nuke, during testing
-// chrome.storage.sync.clear()
-
-var Session = function(sessionProperties) {
+var Session = function(sessionProperties, api = "sync") {
     var Session = this
 
+	Session.api = api
     Session.callbacks = {}
+
+	// Use when you need to nuke, during testing
+	chrome.storage[api].clear()
 
     /* ----
         Class methods
@@ -39,7 +40,7 @@ var Session = function(sessionProperties) {
         var keyValue = {}
         keyValue[property] = value
 
-        chrome.storage.sync.set(
+        chrome.storage[api].set(
             keyValue,
             function sentToStorage() {
                 console.log("SET Session."+property+" = ",value)
@@ -59,7 +60,7 @@ var Session = function(sessionProperties) {
 
     Session.get = function(property,cb) {
         var Session = this
-        chrome.storage.sync.get(property, function receivedPropertyFromStorage(requestedStorage) {
+        chrome.storage[api].get(property, function receivedPropertyFromStorage(requestedStorage) {
             console.log("GET Session."+property+" = ",requestedStorage[property])
             Session[property] = requestedStorage[property]
             if(typeof Session.callbacks[property] === 'function') Session.callbacks[property](Session[property],"get") // on init
@@ -88,7 +89,7 @@ var Session = function(sessionProperties) {
         Constructor
     */
 
-	console.log("--- Loading chrome sync")
+	console.log("--- Loading from chrome.storage."+Session.api)
 	for (var property in sessionProperties) {
 		if(sessionProperties.hasOwnProperty(property) ) {
 			console.log("--- syncing "+property)

--- a/session.js
+++ b/session.js
@@ -4,27 +4,27 @@
 
 /* Usage
 // Create new session
-thisSession = new Session({
+thisChromeStorage = new ChromeStorage({
 	someSyncedProperty: false
 })
 
 // Invert a session property's value
-thisSession.set('someSyncedProperty', !thisSession.someSyncedProperty);
+thisChromeStorage.set('someSyncedProperty', !thisChromeStorage.someSyncedProperty);
 
 // Listen for session property changes
-thisSession.onChange({
+thisChromeStorage.onChange({
     someSyncedProperty: function(newValue) {
 		// Access a session property
-		console.log(newValue == thisSession.someSyncedProperty) => true
+		console.log(newValue == thisChromeStorage.someSyncedProperty) => true
 	},
 });
 */
 
-var Session = function(sessionProperties, api = "sync") {
-    var Session = this
+var ChromeStorage = function(sessionProperties, api = "sync") {
+    var ChromeStorage = this
 
-	Session.api = api
-    Session.callbacks = {}
+	ChromeStorage.api = api
+    ChromeStorage.callbacks = {}
 
 	// Use when you need to nuke, during testing
 	chrome.storage[api].clear()
@@ -33,9 +33,9 @@ var Session = function(sessionProperties, api = "sync") {
         Class methods
     */
 
-    Session.set = function(property,value,cb) {
-        var Session = this
-        Session[property] = value
+    ChromeStorage.set = function(property,value,cb) {
+        var ChromeStorage = this
+        ChromeStorage[property] = value
 
         var keyValue = {}
         keyValue[property] = value
@@ -43,57 +43,57 @@ var Session = function(sessionProperties, api = "sync") {
         chrome.storage[api].set(
             keyValue,
             function sentToStorage() {
-                console.log("SET Session."+property+" = ",value)
-                if(typeof Session.callbacks[property] === 'function') Session.callbacks[property](value,"set")
+                console.log("SET ChromeStorage."+property+" = ",value)
+                if(typeof ChromeStorage.callbacks[property] === 'function') ChromeStorage.callbacks[property](value,"set")
                 if(typeof cb === 'function') cb(value)
             }
         )
-        return Session[property]
+        return ChromeStorage[property]
     }
 
-	Session.add = function(property,newValue,cb) {
-        var Session = this;
-		var updatedArray = Session[property];
+	ChromeStorage.add = function(property,newValue,cb) {
+        var ChromeStorage = this;
+		var updatedArray = ChromeStorage[property];
 		updatedArray.push(newValue);
-		Session.set(property, updatedArray, cb);
+		ChromeStorage.set(property, updatedArray, cb);
 	}
 
-    Session.get = function(property,cb) {
-        var Session = this
+    ChromeStorage.get = function(property,cb) {
+        var ChromeStorage = this
         chrome.storage[api].get(property, function receivedPropertyFromStorage(requestedStorage) {
-            console.log("GET Session."+property+" = ",requestedStorage[property])
-            Session[property] = requestedStorage[property]
-            if(typeof Session.callbacks[property] === 'function') Session.callbacks[property](Session[property],"get") // on init
-            if(typeof cb === 'function') cb(Session[property])
+            console.log("GET ChromeStorage."+property+" = ",requestedStorage[property])
+            ChromeStorage[property] = requestedStorage[property]
+            if(typeof ChromeStorage.callbacks[property] === 'function') ChromeStorage.callbacks[property](ChromeStorage[property],"get") // on init
+            if(typeof cb === 'function') cb(ChromeStorage[property])
         })
     }
 
-	Session.init = function(property,defaultValue,cb) {
-        var Session = this;
-		Session.get(property, function(storageValue) {
+	ChromeStorage.init = function(property,defaultValue,cb) {
+        var ChromeStorage = this;
+		ChromeStorage.get(property, function(storageValue) {
 			if(storageValue != undefined) {
 				console.log("Synced "+property+" with server: ",storageValue)
 			} else {
 				console.log("Resetting "+property+" to ",defaultValue)
-				Session.set(property,defaultValue,cb);
+				ChromeStorage.set(property,defaultValue,cb);
 			}
 		})
 	}
 
-    Session.onChange = function(callbackObj) {
-        var Session = this
-		Object.assign(Session.callbacks, callbackObj)
+    ChromeStorage.onChange = function(callbackObj) {
+        var ChromeStorage = this
+		Object.assign(ChromeStorage.callbacks, callbackObj)
     }
 
     /* ----
         Constructor
     */
 
-	console.log("--- Loading from chrome.storage."+Session.api)
+	console.log("--- Loading from chrome.storage."+ChromeStorage.api)
 	for (var property in sessionProperties) {
 		if(sessionProperties.hasOwnProperty(property) ) {
 			console.log("--- syncing "+property)
-	        Session.init(property, sessionProperties[property]);
+	        ChromeStorage.init(property, sessionProperties[property]);
 		}
 	}
 }

--- a/session.js
+++ b/session.js
@@ -27,7 +27,7 @@ var ChromeStorage = function(sessionProperties, api = "sync") {
     ChromeStorage.callbacks = {}
 
 	// Use when you need to nuke, during testing
-	chrome.storage[api].clear()
+	// chrome.storage[api].clear()
 
     /* ----
         Class methods


### PR DESCRIPTION
Long story short:
* FIXED: Sometimes new ads don't get recorded, because facebook reloads the timeline without reloading the page
* FIXED: `chrome.storage.sync` fills up too quickly (only 100kb) so I've split it. 
** Sync storage carries the metadata advert history of a user.
** Each browser's local storage (couple of MB space) now carries the full archive record, minus HTML.
** Server storage still holds everything.
* FIXED: `manifest.json` had two `permissions` fields -- my bad.